### PR TITLE
Upgrade dependencies, update for newer React Native

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,9 +15,9 @@
     "output"
   ],
   "dependencies": {
-    "purescript-console": "^0.1.0",
-    "purescript-react": "~0.5.0",
-    "purescript-functions": "~0.1.0"
+    "purescript-react": "^1.1.0",
+    "purescript-functions": "^1.0.0",
+    "purescript-console": "^1.0.0"
   },
   "authors": [
     "Nicholas Kariniemi <nicholas.kariniemi@gmail.com>"

--- a/src/ReactNative/Components.js
+++ b/src/ReactNative/Components.js
@@ -54,6 +54,11 @@ exports.createElementOneChild = function(clazz) {
     }
 };
 
+exports.createElementNoChildren = function(clazz) {
+    return function(props) {
+        return React.createElement(clazz, props.length > 0 ? mkProps(props) : null);
+    }
+};
 exports.textElem = function(text) {
     return text;
 };

--- a/src/ReactNative/Components.purs
+++ b/src/ReactNative/Components.purs
@@ -2,12 +2,13 @@ module ReactNative.Components where
 
 import Prelude
 import React (ReactClass(), ReactElement())
-import React.DOM.Props (Props())
+import React.DOM.Props (Props(), unsafeMkProps)
 
 foreign import data ListViewDataSource :: *
 
 foreign import createElement :: forall props. ReactClass props -> props -> Array ReactElement -> ReactElement
 foreign import createElementOneChild :: forall props. ReactClass props -> props -> ReactElement -> ReactElement
+foreign import createElementNoChildren :: forall props. ReactClass props -> props -> ReactElement
 foreign import viewClass :: forall props. ReactClass props
 foreign import textElem :: String -> ReactElement
 foreign import textClass :: forall props. ReactClass props
@@ -36,5 +37,11 @@ touchableHighlight = createElementOneChild touchableHighlightClass
 touchableNativeFeedback :: Array Props -> ReactElement -> ReactElement
 touchableNativeFeedback = createElementOneChild touchableNativeFeedbackClass
 
+multiline :: Boolean -> Props
+multiline = unsafeMkProps "multiline"
+
 textInput :: Array Props -> ReactElement
-textInput props = createElement textInputClass props []
+textInput props = createElementNoChildren textInputClass (props <> [multiline false])
+
+textInput' :: Array Props -> ReactElement
+textInput' props = createElement textInputClass (props <> [multiline true]) []

--- a/src/ReactNative/Props.js
+++ b/src/ReactNative/Props.js
@@ -2,11 +2,22 @@
 
 // module ReactNative.Props
 
+var RN = require('react-native');
+var TouchableNativeFeedback = RN.TouchableNativeFeedback;
+var Platform = RN.Platform;
+
 exports.unitFn = function(data){
   return function(){
     return data;
   }
 }
 
-exports.selectableBackground = require('react-native').TouchableNativeFeedback.SelectableBackground();
-exports.selectableBackgroundBorderless = require('react-native').TouchableNativeFeedback.SelectableBackgroundBorderless();
+var isAndroid = Platform.OS === 'android';
+
+exports.selectableBackground = isAndroid ? TouchableNativeFeedback.SelectableBackground() : null;
+exports.selectableBackgroundBorderless = isAndroid ? TouchableNativeFeedback.SelectableBackgroundBorderless() : null;
+exports.ripple = function (color) {
+  return function (borderless) {
+    return TouchableNativeFeedback.Ripple(color, borderless);
+  }
+};

--- a/src/ReactNative/Props.purs
+++ b/src/ReactNative/Props.purs
@@ -2,7 +2,7 @@ module ReactNative.Props where
 
 import Prelude
 import Control.Monad.Eff (Eff())
-import Data.Function (mkFn0, mkFn3, mkFn4)
+import Data.Function.Uncurried (mkFn3, mkFn4)
 import React (ReactElement(), Event(), EventHandlerContext(), handle)
 import React.DOM.Props (Props(), unsafeMkProps)
 import ReactNative.Components (ListViewDataSource())
@@ -27,7 +27,7 @@ renderFooter :: ReactElement -> Props
 renderFooter elem = unsafeMkProps "renderFooter" (unitFn elem)
 
 dataSource :: ListViewDataSource -> Props
-dataSource = unsafeMkProps "dataSource" 
+dataSource = unsafeMkProps "dataSource"
 
 onPress :: forall eff props state result. (Event -> EventHandlerContext eff props state result) -> Props
 onPress f = unsafeMkProps "onPress" (handle f)
@@ -49,4 +49,4 @@ foreign import selectableBackground :: NativeFeedbackBackground
 foreign import selectableBackgroundBorderless :: NativeFeedbackBackground
 
 background :: NativeFeedbackBackground -> Props
-background = unsafeMkProps "background" 
+background = unsafeMkProps "background"

--- a/src/ReactNative/Props.purs
+++ b/src/ReactNative/Props.purs
@@ -47,6 +47,7 @@ onChangeText f = unsafeMkProps "onChangeText" (handle f)
 foreign import data NativeFeedbackBackground :: *
 foreign import selectableBackground :: NativeFeedbackBackground
 foreign import selectableBackgroundBorderless :: NativeFeedbackBackground
+foreign import ripple :: String -> Boolean -> NativeFeedbackBackground
 
 background :: NativeFeedbackBackground -> Props
 background = unsafeMkProps "background"


### PR DESCRIPTION
Upgrades dependencies and makes updates based on some red page errors given off by RN 0.30 (i.e. TextInput and TouchableNativeFeedback being Android-only)

Builds and works with iOS: https://github.com/justinwoo/purescript-react-native-todomvc

Admittedly, throws warnings about PropType checking being used somewhere, so might be worth tracking that down...
